### PR TITLE
Added sample output to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,16 @@ int _tmain(int argc, _TCHAR* argv[])
 }
 ```
 
+## Sample Output ##
+
+The above example program generates the following output:
+
+```
+nop
+jmp 00000006
+ret
+```
+
 ## Compilation ##
 
 Zydis builds cleanly on most platforms without any external dependencies. You can use CMake to generate project files for your favorite C++14 compiler.


### PR DESCRIPTION
When evaluating various disassembly libraries, I wanted to see how the output from Zydis looked with the default formatter. If sample output from the example program is added to the README file, potential users won't have to download and build Zydis just to find out if the output is suitable for their needs.